### PR TITLE
Move file management to a separate page. #21

### DIFF
--- a/src/lib/nav.test.ts
+++ b/src/lib/nav.test.ts
@@ -44,7 +44,11 @@ describe("getBreadcrumbLinks", () => {
 
 describe("getPrevPage", () => {
   it("normal cases", () => {
-    expect(getPrevPage("/cross_section/summary")).toBe(null);
+    expect(getPrevPage("/cross_section/files")).toBe(null);
+    expect(getPrevPage("/cross_section/summary")).toStrictEqual([
+      "/cross_section/files",
+      "Manage files",
+    ]);
     expect(getPrevPage("/cross_section/proposed")).toStrictEqual([
       "/cross_section/summary",
       "Summary of Scheme",

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -3,12 +3,14 @@ let pages: [string, string][] = [
   ["/", "Tools"],
 
   ["/cross_section", "Route cross-section tool"],
+  ["/cross_section/files", "Manage files"],
   ["/cross_section/summary", "Summary of Scheme"],
   ["/cross_section/proposed", "Proposed Cross-Sections"],
   ["/cross_section/check", "Cross-Sections Check"],
   ["/cross_section/results_summary", "ATE Summary"],
 
   ["/area_check", "Area check tool"],
+  ["/area_check/files", "Manage files"],
   ["/area_check/summary", "Summary of Scheme"],
   ["/area_check/traffic_mitigation", "Traffic Mitigation Check"],
   ["/area_check/scorecard", "Area Scorecard"],
@@ -28,6 +30,7 @@ let pages: [string, string][] = [
   ["/area_check/results", "Results & Commentary"],
 
   ["/route_check", "Route check tool"],
+  ["/route_check/files", "Manage files"],
   ["/route_check/summary", "Summary of Scheme"],
   ["/route_check/policy_check", "Policy Check"],
   ["/route_check/safety_check", "Safety Check"],

--- a/src/routes/area_check/+layout.svelte
+++ b/src/routes/area_check/+layout.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-  import { FileManager } from "$lib/files";
-  import { files, currentFile, state } from "./data";
+  import { currentFile } from "./data";
+  import { base } from "$app/paths";
 </script>
 
-<FileManager {files} {currentFile} {state} xlsxImporter={null} />
+<div>
+  <a href="{base}/area_check/files">Manage files</a>
+  <span>
+    Editing file <u>{$currentFile}</u>
+  </span>
+</div>
 
 <hr />
 

--- a/src/routes/area_check/files/+layout@.svelte
+++ b/src/routes/area_check/files/+layout@.svelte
@@ -1,0 +1,3 @@
+<!-- Avoid area_check/layout.svelte, because we don't need a link to this page -->
+<hr />
+<slot />

--- a/src/routes/area_check/files/+page.svelte
+++ b/src/routes/area_check/files/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { FileManager } from "$lib/files";
+  import { files, currentFile, state } from "../data";
+</script>
+
+<FileManager {files} {currentFile} {state} />

--- a/src/routes/cross_section/+layout.svelte
+++ b/src/routes/cross_section/+layout.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-  import { FileManager } from "$lib/files";
-  import { files, currentFile, state } from "./data";
+  import { currentFile } from "./data";
+  import { base } from "$app/paths";
 </script>
 
-<FileManager {files} {currentFile} {state} xlsxImporter={null} />
+<div>
+  <a href="{base}/cross_section/files">Manage files</a>
+  <span>
+    Editing file <u>{$currentFile}</u>
+  </span>
+</div>
 
 <hr />
 

--- a/src/routes/cross_section/files/+layout@.svelte
+++ b/src/routes/cross_section/files/+layout@.svelte
@@ -1,0 +1,3 @@
+<!-- Avoid cross_section/layout.svelte, because we don't need a link to this page -->
+<hr />
+<slot />

--- a/src/routes/cross_section/files/+page.svelte
+++ b/src/routes/cross_section/files/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import { FileManager } from "$lib/files";
+  import { files, currentFile, state } from "../data";
+</script>
+
+<FileManager {files} {currentFile} {state} />

--- a/src/routes/route_check/+layout.svelte
+++ b/src/routes/route_check/+layout.svelte
@@ -1,18 +1,14 @@
 <script lang="ts">
-  import { FileManager } from "$lib/files";
-  import { files, currentFile, state, type State } from "./data";
-  import { getDalog, dalogToState } from "$lib/import";
-  import ExcelJS from "exceljs";
-
-  async function xlsxImporter(buffer: ArrayBuffer): Promise<State> {
-    let workbook = new ExcelJS.Workbook();
-    await workbook.xlsx.load(buffer);
-    let dalog = getDalog(workbook);
-    return dalogToState(dalog);
-  }
+  import { currentFile } from "./data";
+  import { base } from "$app/paths";
 </script>
 
-<FileManager {files} {currentFile} {state} {xlsxImporter} />
+<div>
+  <a href="{base}/route_check/files">Manage files</a>
+  <span>
+    Editing file <u>{$currentFile}</u>
+  </span>
+</div>
 
 <hr />
 

--- a/src/routes/route_check/files/+layout@.svelte
+++ b/src/routes/route_check/files/+layout@.svelte
@@ -1,0 +1,3 @@
+<!-- Avoid route_check/layout.svelte, because we don't need a link to this page -->
+<hr />
+<slot />

--- a/src/routes/route_check/files/+page.svelte
+++ b/src/routes/route_check/files/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { FileManager } from "$lib/files";
+  import { files, currentFile, state, type State } from "../data";
+  import { getDalog, dalogToState } from "$lib/import";
+  import ExcelJS from "exceljs";
+
+  async function xlsxImporter(buffer: ArrayBuffer): Promise<State> {
+    let workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.load(buffer);
+    let dalog = getDalog(workbook);
+    return dalogToState(dalog);
+  }
+</script>
+
+<FileManager {files} {currentFile} {state} {xlsxImporter} />


### PR DESCRIPTION
This avoids bugs when suddenly swapping state on certain pages and will help with a more clear UX.

For now, choosing to show this page in the breadcrumbs. The "splash page" for each tool is still the overview, but we could decide to force people to start with the file manager instead.