### PR TITLE
Fix problems on GH pages and make the nav header more consistent

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -11,30 +11,14 @@ export function pairs(list: string[]): [string, string][] {
   return list.map((x) => [x, x]);
 }
 
+// Capitalise the first letter of each word
 export function capitaliseWords(words: string): string {
-  let wordsList: string[] = words.split(" ");
-
-  let capitalisedWordsString: string = wordsList.reduce(
-    (accumulator, currentValue) => {
-      return (
-        accumulator +
-        " " +
-        currentValue[0].toUpperCase() +
-        currentValue.substring(1)
-      );
-    },
-    "",
-  );
-
-  if (capitalisedWordsString[0] === " ") {
-    capitalisedWordsString = capitalisedWordsString.substring(1);
-  }
-  const length = capitalisedWordsString.length;
-  if (capitalisedWordsString[length - 1] === " ") {
-    capitalisedWordsString = capitalisedWordsString.substring(0, length - 1);
-  }
-
-  return capitalisedWordsString;
+  return words
+    .split(" ")
+    .map((word) =>
+      word.length > 0 ? word[0].toUpperCase() + word.substr(1) : word,
+    )
+    .join(" ");
 }
 
 export function repeatCloned<T>(length: number, x: T): T[] {

--- a/src/lib/nav/NavHeader.svelte
+++ b/src/lib/nav/NavHeader.svelte
@@ -43,13 +43,9 @@
     style="display: flex; justify-content: space-around; flex-direction: row; flex-wrap: wrap;"
   >
     {#each navList as navItem}
-      {#if navItem[2]}
-        <li>{navItem[1]}</li>
-      {:else}
-        <li>
-          <a href="{base}{navItem[0]}">{navItem[1]}</a>
-        </li>
-      {/if}
+      <li>
+        <a href="{base}{navItem[0]}">{navItem[1]}</a>
+      </li>
     {/each}
   </ol>
 {/if}

--- a/src/lib/nav/index.ts
+++ b/src/lib/nav/index.ts
@@ -247,7 +247,7 @@ let mainPageSections = pages.filter(([x, _]) => x.split("/").length == 3);
 let pathToTitle = new Map(pages);
 
 export function getTitle(path: string): string {
-  let titleAnyCase = pathToTitle.get(canonicalizePath(path))!;
+  let titleAnyCase = pathToTitle.get(canonicalizePath(path)) || "";
   return capitaliseWords(titleAnyCase);
 }
 
@@ -395,9 +395,11 @@ function canonicalizePath(path: string): string {
   // Remove trailing slashes
   path = path.replace(/\/+$/, "");
 
-  // When deployed to GH Pages, remove the leading base path.
-  if (path.startsWith("/inspectorate_tools")) {
-    path = path.slice("/inspectorate_tools".length);
+  // When deployed to GH Pages, remove the leading base path. This is just
+  // /inspectorate_tools for the main branch, but other git branches have
+  // the branch name prefixed there.
+  if (path.startsWith(import.meta.env.BASE_URL)) {
+    path = path.slice(import.meta.env.BASE_URL.length);
   }
 
   // Guarantee a leading slash

--- a/src/lib/nav/index.ts
+++ b/src/lib/nav/index.ts
@@ -375,7 +375,7 @@ export function getNextPage(
 export function getNavList(
   rawPath: string,
   routeCheckType: "street" | "path" | "",
-): [string, string, boolean][] | null {
+): [string, string][] | null {
   let path = getSectionPath(rawPath);
   if (!path) {
     return null;
@@ -383,20 +383,9 @@ export function getNavList(
 
   let sections = filterMainPageSections(routeCheckType);
   const toolName = path != "/" ? path.split("/")[1] : "";
-  sections = sections.filter((section) => {
+  return sections.filter((section) => {
     return section[0] != "/" && section[0].split("/")[1] == toolName;
   });
-  let idx = sections.findIndex((pair) => pair[0] == path);
-  const result: [string, string, boolean][] = sections.map((section) => [
-    section[0],
-    section[1],
-    false,
-  ]);
-
-  if (idx >= 0) {
-    result[idx][2] = true;
-  }
-  return result;
 }
 
 function canonicalizePath(path: string): string {

--- a/src/lib/nav/nav.test.ts
+++ b/src/lib/nav/nav.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { capitaliseWords } from "../";
 import { getTitle, getBreadcrumbLinks, getPrevPage, getNextPage } from "./";
 
 describe("getTitle", () => {
@@ -19,6 +20,7 @@ describe("getTitle", () => {
   });
 
   it("GH deployment", () => {
+    import.meta.env.BASE_URL = "/inspectorate_tools";
     expect(getTitle("/inspectorate_tools")).toBe("Tools");
     expect(getTitle("/inspectorate_tools/")).toBe("Tools");
     expect(getTitle("/inspectorate_tools/cross_section/proposed/")).toBe(
@@ -153,5 +155,14 @@ describe("getNextPage", () => {
     expect(
       getNextPage("/route_check/path_placemaking_check", "path"),
     ).toStrictEqual(["/route_check/jat_check", "JAT Check"]);
+  });
+});
+
+describe("capitaliseWords", () => {
+  it("normal cases", () => {
+    expect(capitaliseWords("")).toBe("");
+    expect(capitaliseWords("  ")).toBe("  ");
+    expect(capitaliseWords("foo bar 123")).toBe("Foo Bar 123");
+    expect(capitaliseWords("FOO Bar 123")).toBe("FOO Bar 123");
   });
 });


### PR DESCRIPTION
First up, we had a problem on GH branches, which get deployed to GH pages as /inspectorate/tools/branch_name. There were some crashes in the nav code, which stops the page from being rendered. I've fixed those bugs and simplified the code, see comments below.

Second, when previously you were on a page like https://acteng.github.io/inspectorate_tools/route_check/safety_check/sa04, the nav header didn't have a link for the Safety Check section:
![image](https://github.com/user-attachments/assets/3b072300-20da-462f-9185-ee762bfb8d4d)
This felt like a usability annoyance to me; I kept trying to click that to return easily to the overview page with all questions. So, changing it to always keep the links active.

I'm going to merge this immediately to fix the first bug and be able to demo other branches again, but async feedback welcome.