### PR TITLE
Fix govuk styles

### DIFF
--- a/src/lib/nav/NavFooter.svelte
+++ b/src/lib/nav/NavFooter.svelte
@@ -23,7 +23,9 @@
     &nbsp;
   {/if}
 
-  <span style="display: flex; align-items: center">{getTitle(pagePath)}</span>
+  <span class="govuk-body" style="display: flex; align-items: center">
+    {getTitle(pagePath)}
+  </span>
 
   {#if nextPage}
     <NextButton href="{base}{nextPage[0]}" label={nextPage[1]} />
@@ -31,9 +33,3 @@
     &nbsp;
   {/if}
 </div>
-
-<style>
-  span {
-    font-family: "GDS Transport", arial, sans-serif;
-  }
-</style>

--- a/src/lib/nav/NavHeader.svelte
+++ b/src/lib/nav/NavHeader.svelte
@@ -52,7 +52,6 @@
 
 <style>
   li {
-    font-family: "GDS Transport", arial, sans-serif;
     margin-left: 2em;
   }
   li:first-child {

--- a/src/routes/area_check/+layout.svelte
+++ b/src/routes/area_check/+layout.svelte
@@ -9,7 +9,7 @@
 <div>
   <img src={folderUrl} alt="Manage files" style="vertical-align: middle;" />
   <a href="{base}/area_check/files">Manage files</a>
-  <span class="editing" style="margin-left: 8px;">
+  <span class="govuk-body" style="margin-left: 8px;">
     Editing file <u>{$currentFile}</u>
   </span>
 </div>
@@ -25,9 +25,3 @@
 <hr />
 
 <NavFooter routeCheckType="" />
-
-<style>
-  .editing {
-    font-family: "GDS Transport", arial, sans-serif;
-  }
-</style>

--- a/src/routes/cross_section/+layout.svelte
+++ b/src/routes/cross_section/+layout.svelte
@@ -9,7 +9,7 @@
 <div>
   <img src={folderUrl} alt="Manage files" style="vertical-align: middle;" />
   <a href="{base}/cross_section/files">Manage files</a>
-  <span class="editing" style="margin-left: 8px;">
+  <span class="govuk-body" style="margin-left: 8px;">
     Editing file <u>{$currentFile}</u>
   </span>
 </div>
@@ -25,9 +25,3 @@
 <hr />
 
 <NavFooter routeCheckType="" />
-
-<style>
-  .editing {
-    font-family: "GDS Transport", arial, sans-serif;
-  }
-</style>

--- a/src/routes/planning/+layout.svelte
+++ b/src/routes/planning/+layout.svelte
@@ -9,7 +9,7 @@
 <div>
   <img src={folderUrl} alt="Manage files" style="vertical-align: middle;" />
   <a href="{base}/planning/files">Manage files</a>
-  <span class="editing" style="margin-left: 8px;">
+  <span class="govuk-body" style="margin-left: 8px;">
     Editing file <u>{$currentFile}</u>
   </span>
 </div>
@@ -25,9 +25,3 @@
 <hr />
 
 <NavFooter routeCheckType="" />
-
-<style>
-  .editing {
-    font-family: "GDS Transport", arial, sans-serif;
-  }
-</style>

--- a/src/routes/route_check/+layout.svelte
+++ b/src/routes/route_check/+layout.svelte
@@ -9,7 +9,7 @@
 <div>
   <img src={folderUrl} alt="Manage files" style="vertical-align: middle;" />
   <a href="{base}/route_check/files">Manage files</a>
-  <span class="editing" style="margin-left: 8px;">
+  <span class="govuk-body" style="margin-left: 8px;">
     Editing file <u>{$currentFile}</u>
   </span>
 </div>
@@ -25,9 +25,3 @@
 <hr />
 
 <NavFooter routeCheckType={$state.summary.checkType} />
-
-<style>
-  .editing {
-    font-family: "GDS Transport", arial, sans-serif;
-  }
-</style>

--- a/src/routes/route_check/+page.svelte
+++ b/src/routes/route_check/+page.svelte
@@ -74,9 +74,3 @@
   <li><a href="{base}/route_check/results_export">Results Export</a></li>
   <li><a href="{base}/route_check/dalog">Design Assistance Log</a></li>
 </ol>
-
-<style>
-  li {
-    font-family: "GDS Transport", arial, sans-serif;
-  }
-</style>

--- a/src/routes/route_check/GenericProgress.svelte
+++ b/src/routes/route_check/GenericProgress.svelte
@@ -174,9 +174,6 @@
     padding: 4px;
     text-align: center;
   }
-  li {
-    font-family: "GDS Transport", arial, sans-serif;
-  }
   h3 {
     margin-top: 0.75em;
     margin-bottom: 0.75em;

--- a/src/style/main.sass
+++ b/src/style/main.sass
@@ -17,9 +17,9 @@
   a
     @extend .govuk-link
   ul
-    @extend .govuk-list--bullet
+    @extend .govuk-list, .govuk-list--bullet
   ol
-    @extend .govuk-list--number
+    @extend .govuk-list, .govuk-list--number
 
   table
     @extend .govuk-table


### PR DESCRIPTION
#58 made some individual fixes to fonts, but I think my replies got lost. The SASS for lists was missing a class, so the font wasn't set. This fixes that, and also switches from specifying the font manually on `<span>`s to using the [govuk-body](https://design-system.service.gov.uk/styles/paragraphs/) class. We should never need to specify fonts manually; they're an internal implementation detail.

It's not appropriate to apply `govuk-body` to all spans in the SASS file, because spans are used for many places. I've audited all of them to make sure if they have text, then they have this class set or are part of a larger element that sets the font