### PR TITLE
A variety of simple fixes

### DIFF
--- a/src/lib/files/FileManager.svelte
+++ b/src/lib/files/FileManager.svelte
@@ -143,13 +143,15 @@
     </SecondaryButton>
     <SecondaryButton on:click={exportFile}>
       <img src={downloadUrl} alt="Download this file" />
-      Download this file
+      Export .json
     </SecondaryButton>
     <WarningButton on:click={() => deleteFile($currentFile)}>
       <img src={deleteUrl} alt="Delete this file" />
       Delete this file
     </WarningButton>
   </ButtonGroup>
+
+  <slot />
 
   <hr />
 

--- a/src/lib/files/FileManager.svelte
+++ b/src/lib/files/FileManager.svelte
@@ -142,7 +142,7 @@
       Rename this file
     </SecondaryButton>
     <SecondaryButton on:click={exportFile}>
-      <img src={downloadUrl} alt="Download this file" />
+      <img src={downloadUrl} alt="Export .json" />
       Export .json
     </SecondaryButton>
     <WarningButton on:click={() => deleteFile($currentFile)}>

--- a/src/lib/files/FileManager.svelte
+++ b/src/lib/files/FileManager.svelte
@@ -3,12 +3,14 @@
   import deleteUrl from "$lib/assets/images/delete.svg?url";
   import downloadUrl from "$lib/assets/images/download.svg?url";
   import { base } from "$app/paths";
+  import { goto } from "$app/navigation";
   import { LocalStorageFiles } from "./index";
   import {
     FileInput,
     WarningButton,
     ButtonGroup,
     SecondaryButton,
+    DefaultButton,
   } from "govuk-svelte";
   import { stripSuffix, ClickableCard } from "$lib";
   import { type Writable } from "svelte/store";
@@ -177,9 +179,15 @@
               ? "Currently open"
               : files.describeFile(filename)}
           </ClickableCard>
-          <WarningButton on:click={() => deleteFile(filename)}>
-            Delete
-          </WarningButton>
+          {#if filename == $currentFile}
+            <DefaultButton on:click={() => goto(`${base}/${files.prefix}`)}>
+              Start
+            </DefaultButton>
+          {:else}
+            <WarningButton on:click={() => deleteFile(filename)}>
+              Delete
+            </WarningButton>
+          {/if}
         </div>
       {/each}
     </div>

--- a/src/routes/route_check/+page.svelte
+++ b/src/routes/route_check/+page.svelte
@@ -4,73 +4,76 @@
   import { state } from "./data";
 </script>
 
-<p>
-  This is an experimental version of a <ExternalLink
-    href="https://www.gov.uk/government/publications/active-travel-england-scheme-review-tools"
-  >
-    scheme review tool
-  </ExternalLink>.
-</p>
+<div class="govuk-width-container">
+  <p>
+    This is an experimental version of a <ExternalLink
+      href="https://www.gov.uk/government/publications/active-travel-england-scheme-review-tools"
+    >
+      scheme review tool
+    </ExternalLink>.
+  </p>
 
-<ol>
-  <li><a href="{base}/route_check/summary">Summary of Scheme</a></li>
-  <li><a href="{base}/route_check/policy_check">Policy Check</a></li>
+  <ol>
+    <li><a href="{base}/route_check/summary">Summary of Scheme</a></li>
+    <li><a href="{base}/route_check/policy_check">Policy Check</a></li>
 
-  <li><a href="{base}/route_check/safety_check">Safety Check</a></li>
-  <li>
-    <a href="{base}/route_check/problems_map">Problems Mapping Page</a>
-  </li>
+    <li><a href="{base}/route_check/safety_check">Safety Check</a></li>
+    <li>
+      <a href="{base}/route_check/problems_map">Problems Mapping Page</a>
+    </li>
 
-  {#if $state.summary.checkType == "street"}
-    <li><a href="{base}/route_check/street_check">Street Check</a></li>
-    <li>
-      <a href="{base}/route_check/street_placemaking_check">
-        Street Placemaking Check
-      </a>
-    </li>
-  {:else}
-    <li>
-      <i>
-        Street Check (disabled, because of the Route Check Type set in Summary)
-      </i>
-    </li>
-    <li>
-      <i>
-        Street Placemaking Check (disabled, because of the Route Check Type set
-        in Summary)
-      </i>
-    </li>
-  {/if}
+    {#if $state.summary.checkType == "street"}
+      <li><a href="{base}/route_check/street_check">Street Check</a></li>
+      <li>
+        <a href="{base}/route_check/street_placemaking_check">
+          Street Placemaking Check
+        </a>
+      </li>
+    {:else}
+      <li>
+        <i>
+          Street Check (disabled, because of the Route Check Type set in
+          Summary)
+        </i>
+      </li>
+      <li>
+        <i>
+          Street Placemaking Check (disabled, because of the Route Check Type
+          set in Summary)
+        </i>
+      </li>
+    {/if}
 
-  {#if $state.summary.checkType == "path"}
-    <li><a href="{base}/route_check/path_check">Path Check</a></li>
-    <li>
-      <a href="{base}/route_check/path_placemaking_check">
-        Path Placemaking Check
-      </a>
-    </li>
-  {:else}
-    <li>
-      <i>
-        Path Check (disabled, because of the Route Check Type set in Summary)
-      </i>
-    </li>
-    <li>
-      <i>
-        Path Placemaking Check (disabled, because of the Route Check Type set in
-        Summary)
-      </i>
-    </li>
-  {/if}
+    {#if $state.summary.checkType == "path"}
+      <li><a href="{base}/route_check/path_check">Path Check</a></li>
+      <li>
+        <a href="{base}/route_check/path_placemaking_check">
+          Path Placemaking Check
+        </a>
+      </li>
+    {:else}
+      <li>
+        <i>
+          Path Check (disabled, because of the Route Check Type set in Summary)
+        </i>
+      </li>
+      <li>
+        <i>
+          Path Placemaking Check (disabled, because of the Route Check Type set
+          in Summary)
+        </i>
+      </li>
+    {/if}
 
-  <li><a href="{base}/route_check/jat_check">JAT Check</a></li>
+    <li><a href="{base}/route_check/jat_check">JAT Check</a></li>
 
-  <li>
-    <a href="{base}/route_check/results_summary">Results Summary</a>
-  </li>
-  <li>
-    <a href="{base}/route_check/results_analysis">Results Further Analysis</a>
-  </li>
-  <li><a href="{base}/route_check/results_export">Results Export</a></li>
-  <li><a href="{base}/route_check/dalog">Design Assistance Log</a></li>
-</ol>
+    <li>
+      <a href="{base}/route_check/results_summary">Results Summary</a>
+    </li>
+    <li>
+      <a href="{base}/route_check/results_analysis">Results Further Analysis</a>
+    </li>
+    <li><a href="{base}/route_check/results_export">Results Export</a></li>
+    <li><a href="{base}/route_check/dalog">Design Assistance Log</a></li>
+  </ol>
+</div>

--- a/src/routes/route_check/dalog/+page.svelte
+++ b/src/routes/route_check/dalog/+page.svelte
@@ -10,18 +10,20 @@
   let values = pairs.map((pair) => `"${pair[1]}"`).join("\t");
 </script>
 
-<ConvertToXlsx />
+<div class="govuk-width-container">
+  <ConvertToXlsx />
 
-<p>
-  This page is for internal use only. The values below are TSV (tab-separated
-  values), copyable into Excel.
-</p>
+  <p>
+    This page is for internal use only. The values below are TSV (tab-separated
+    values), copyable into Excel.
+  </p>
 
-<TextArea label="TSV output, just the one row of values" value={values} />
+  <TextArea label="TSV output, just the one row of values" value={values} />
 
-<TextArea label="TSV output with header" value={`${header}\n${values}\n`} />
+  <TextArea label="TSV output with header" value={`${header}\n${values}\n`} />
 
-<TextArea
-  label="JSON mapping"
-  value={JSON.stringify(Object.fromEntries(pairs), null, "  ")}
-/>
+  <TextArea
+    label="JSON mapping"
+    value={JSON.stringify(Object.fromEntries(pairs), null, "  ")}
+  />
+</div>

--- a/src/routes/route_check/data.ts
+++ b/src/routes/route_check/data.ts
@@ -89,47 +89,49 @@ export interface Scorecard {
 }
 
 export interface PolicyConflict {
-  conflict: "1" | "2" | "3" | "4" | "5" | "6" | "";
+  conflict: PolicyConflictCode;
   stage: "Existing" | "Design" | "";
   point: Position;
   locationName: string;
   resolved: "Yes" | "No" | "";
   notes: string;
 }
+export type PolicyConflictCode = "1" | "2" | "3" | "4" | "5" | "6" | "";
 
 export interface CriticalIssue {
-  criticalIssue:
-    | "1"
-    | "2"
-    | "3"
-    | "4"
-    | "5A"
-    | "5B"
-    | "6A"
-    | "6B"
-    | "7A"
-    | "7B"
-    | "8"
-    | "9A"
-    | "9B"
-    | "10"
-    | "11A"
-    | "11B"
-    | "11C"
-    | "11D"
-    | "12A"
-    | "12B"
-    | "13"
-    | "14"
-    | "15"
-    | "16"
-    | "";
+  criticalIssue: CriticalIssueCode;
   stage: "Existing" | "Design" | "";
   point: Position;
   locationName: string;
   resolved: "Yes" | "No" | "";
   notes: string;
 }
+export type CriticalIssueCode =
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5A"
+  | "5B"
+  | "6A"
+  | "6B"
+  | "7A"
+  | "7B"
+  | "8"
+  | "9A"
+  | "9B"
+  | "10"
+  | "11A"
+  | "11B"
+  | "11C"
+  | "11D"
+  | "12A"
+  | "12B"
+  | "13"
+  | "14"
+  | "15"
+  | "16"
+  | "";
 
 export interface Junction {
   name: string;

--- a/src/routes/route_check/files/+page.svelte
+++ b/src/routes/route_check/files/+page.svelte
@@ -3,6 +3,7 @@
   import { files, currentFile, state, type State } from "../data";
   import { getDalog, dalogToState } from "$lib/import";
   import ExcelJS from "exceljs";
+  import ConvertToXlsx from "../results_export/ConvertToXlsx.svelte";
 
   async function xlsxImporter(buffer: ArrayBuffer): Promise<State> {
     let workbook = new ExcelJS.Workbook();
@@ -12,4 +13,6 @@
   }
 </script>
 
-<FileManager {files} {currentFile} {state} {xlsxImporter} />
+<FileManager {files} {currentFile} {state} {xlsxImporter}>
+  <ConvertToXlsx />
+</FileManager>

--- a/src/routes/route_check/jat_check/+page.svelte
+++ b/src/routes/route_check/jat_check/+page.svelte
@@ -55,44 +55,48 @@
 </script>
 
 {#if mode.kind == "list"}
-  <DefaultButton on:click={add}>Add new junction</DefaultButton>
+  <div class="govuk-width-container">
+    <DefaultButton on:click={add}>Add new junction</DefaultButton>
 
-  {#each $state.jat as junction, idx}
-    <ClickableCard
-      name={junction.name || "Untitled junction"}
-      on:click={() => (mode = { kind: "edit", idx, stage: "existing" })}
-    />
-  {/each}
+    {#each $state.jat as junction, idx}
+      <ClickableCard
+        name={junction.name || "Untitled junction"}
+        on:click={() => (mode = { kind: "edit", idx, stage: "existing" })}
+      />
+    {/each}
+  </div>
 {:else if mode.kind == "edit"}
-  <h2>{$state.jat[mode.idx].name || "Untitled junction"} - {mode.stage}</h2>
+  <div class="govuk-width-container">
+    <h2>{$state.jat[mode.idx].name || "Untitled junction"} - {mode.stage}</h2>
 
-  <ButtonGroup>
-    <SecondaryButton on:click={() => (mode = { kind: "list" })}>
-      Back to all junctions
-    </SecondaryButton>
-
-    {#if mode.stage == "proposed"}
-      <SecondaryButton
-        on:click={() =>
-          (mode = { kind: "edit", idx: getIdx(mode), stage: "existing" })}
-      >
-        Edit Existing
+    <ButtonGroup>
+      <SecondaryButton on:click={() => (mode = { kind: "list" })}>
+        Back to all junctions
       </SecondaryButton>
-    {:else}
-      <SecondaryButton
-        on:click={() =>
-          (mode = { kind: "edit", idx: getIdx(mode), stage: "proposed" })}
-      >
-        Edit Proposed
-      </SecondaryButton>
-    {/if}
 
-    <WarningButton on:click={() => deleteJunction(getIdx(mode))}>
-      Delete
-    </WarningButton>
-  </ButtonGroup>
+      {#if mode.stage == "proposed"}
+        <SecondaryButton
+          on:click={() =>
+            (mode = { kind: "edit", idx: getIdx(mode), stage: "existing" })}
+        >
+          Edit Existing
+        </SecondaryButton>
+      {:else}
+        <SecondaryButton
+          on:click={() =>
+            (mode = { kind: "edit", idx: getIdx(mode), stage: "proposed" })}
+        >
+          Edit Proposed
+        </SecondaryButton>
+      {/if}
 
-  <TextInput label="Junction Name" bind:value={$state.jat[mode.idx].name} />
+      <WarningButton on:click={() => deleteJunction(getIdx(mode))}>
+        Delete
+      </WarningButton>
+    </ButtonGroup>
+
+    <TextInput label="Junction Name" bind:value={$state.jat[mode.idx].name} />
+  </div>
 
   {#key mode.stage}
     <EditJunction junctionIdx={mode.idx} stage={mode.stage} />

--- a/src/routes/route_check/jat_check/EditJunction.svelte
+++ b/src/routes/route_check/jat_check/EditJunction.svelte
@@ -77,15 +77,16 @@
   }
 
   function onKeyDown(e: KeyboardEvent) {
-    if (editing != null && e.key == "Escape") {
+    if (editing == null) {
+      return;
+    }
+    let tag = (e.target as HTMLElement).tagName;
+    let formFocused = tag == "INPUT" || tag == "TEXTAREA";
+
+    if (e.key == "Escape" || (e.key == "Enter" && !formFocused)) {
       e.stopPropagation();
       stopEditing();
-    } else if (editing != null && e.key == "Delete") {
-      // Let the delete key work in forms
-      let tag = (e.target as HTMLElement).tagName;
-      if (tag == "INPUT" || tag == "TEXTAREA") {
-        return;
-      }
+    } else if (e.key == "Delete" && !formFocused) {
       e.stopPropagation();
       deleteItem();
     }

--- a/src/routes/route_check/jat_check/EditJunction.svelte
+++ b/src/routes/route_check/jat_check/EditJunction.svelte
@@ -140,10 +140,12 @@
 
 <svelte:window on:keydown={onKeyDown} />
 
-<TextArea
-  label="Commentary / Notes"
-  bind:value={$state.jat[junctionIdx][stage].notes}
-/>
+<div class="govuk-width-container">
+  <TextArea
+    label="Commentary / Notes"
+    bind:value={$state.jat[junctionIdx][stage].notes}
+  />
+</div>
 
 <div style="display: flex; height: 80vh">
   <div

--- a/src/routes/route_check/lists.ts
+++ b/src/routes/route_check/lists.ts
@@ -1,3 +1,5 @@
+import type { CriticalIssueCode } from "./data";
+
 // TODO Preserve bold formatting?
 export let policyConflictChoices: [string, string][] = [
   ["1", "1 - Cyclists are not separated from pedestrians"],
@@ -136,4 +138,13 @@ export function getPolicyConflictIndex(code: string): number {
 // Returns the numeric code and short descripton
 export function getTerseCriticalIssue(code: string): string {
   return code == "" ? "" : getFullCriticalIssue(code).split(":")[0];
+}
+
+// When creating a critical issue from a safety check question, arbitrarily
+// pick a critical type when there are multiple choices.
+export function defaultCriticalType(code: number): CriticalIssueCode {
+  if ([5, 6, 7, 9, 11, 12].includes(code)) {
+    return `${code}A` as CriticalIssueCode;
+  }
+  return code.toString() as CriticalIssueCode;
 }

--- a/src/routes/route_check/policy_check/+page.svelte
+++ b/src/routes/route_check/policy_check/+page.svelte
@@ -29,15 +29,17 @@
         bind:value={$state.policyCheck[idx].proposed}
       />
     </div>
-    {#if $state.policyCheck[idx].existing == "No" || $state.policyCheck[idx].proposed == "No"}
-      <p>
-        <a href="{base}/route_check/problems_map">Log this policy conflict</a>
-      </p>
-    {/if}
     <TextArea
       label="Commentary"
       bind:value={$state.policyCheck[idx].commentary}
     />
+    {#if $state.policyCheck[idx].existing == "No" || $state.policyCheck[idx].proposed == "No"}
+      <p>
+        <a href="{base}/route_check/problems_map?kind=conflict&code={idx + 1}">
+          Log this policy conflict
+        </a>
+      </p>
+    {/if}
 
     {#if idx != questions.length - 1}
       <br />

--- a/src/routes/route_check/problems_map/+page.svelte
+++ b/src/routes/route_check/problems_map/+page.svelte
@@ -242,15 +242,16 @@
   }
 
   function onKeyDown(e: KeyboardEvent) {
-    if (editing != null && e.key == "Escape") {
+    if (editing == null) {
+      return;
+    }
+    let tag = (e.target as HTMLElement).tagName;
+    let formFocused = tag == "INPUT" || tag == "TEXTAREA";
+
+    if (e.key == "Escape" || (e.key == "Enter" && !formFocused)) {
       e.stopPropagation();
       stopEditing();
-    } else if (editing != null && e.key == "Delete") {
-      // Let the delete key work in forms
-      let tag = (e.target as HTMLElement).tagName;
-      if (tag == "INPUT" || tag == "TEXTAREA") {
-        return;
-      }
+    } else if (e.key == "Delete" && !formFocused) {
       e.stopPropagation();
       deleteItem();
     }

--- a/src/routes/route_check/problems_map/+page.svelte
+++ b/src/routes/route_check/problems_map/+page.svelte
@@ -23,6 +23,8 @@
     type State,
     type CriticalIssue,
     type PolicyConflict,
+    type CriticalIssueCode,
+    type PolicyConflictCode,
   } from "../data";
   import {
     getFullPolicyConflict,
@@ -30,6 +32,7 @@
     getCriticalIssueIndex,
     getPolicyConflictIndex,
   } from "../lists";
+  import { page } from "$app/stores";
 
   let map: Map;
   let sidebar: HTMLDivElement;
@@ -37,7 +40,10 @@
   type Kind = "critical" | "conflict";
   type ID = { kind: Kind; idx: number };
 
-  let newKind: Kind = "critical";
+  let urlKind = $page.url.searchParams.get("kind") || "";
+  let newKind: Kind = ["critical", "conflict"].includes(urlKind)
+    ? (urlKind as Kind)
+    : "critical";
   let editing: ID | null = null;
   // When changing to a form, preserve the list position and restore later
   let preserveListScroll: number | null = null;
@@ -146,7 +152,8 @@
       $state.criticalIssues = [
         ...$state.criticalIssues,
         {
-          criticalIssue: "",
+          criticalIssue:
+            ($page.url.searchParams.get("code") as CriticalIssueCode) || "",
           stage: "",
           point: e.detail.lngLat.toArray(),
           locationName: "",
@@ -159,7 +166,8 @@
       $state.policyConflictLog = [
         ...$state.policyConflictLog,
         {
-          conflict: "",
+          conflict:
+            ($page.url.searchParams.get("code") as PolicyConflictCode) || "",
           stage: "",
           point: e.detail.lngLat.toArray(),
           locationName: "",

--- a/src/routes/route_check/results_analysis/+page.svelte
+++ b/src/routes/route_check/results_analysis/+page.svelte
@@ -9,10 +9,12 @@
   let results = getResults($state);
 </script>
 
-<SummaryOfScheme />
+<div class="govuk-width-container">
+  <SummaryOfScheme />
 
-<PolicyCheckResults />
+  <PolicyCheckResults />
 
-<SafetyCheckResults />
+  <SafetyCheckResults />
 
-<CheckDetails {results} />
+  <CheckDetails {results} />
+</div>

--- a/src/routes/route_check/results_export/+page.svelte
+++ b/src/routes/route_check/results_export/+page.svelte
@@ -13,63 +13,65 @@
   let results = getResults($state);
 </script>
 
-<ConvertToXlsx />
+<div class="govuk-width-container">
+  <ConvertToXlsx />
 
-<SummaryOfScheme />
+  <SummaryOfScheme />
 
-<Overview {results} />
+  <Overview {results} />
 
-<h2>Review statement</h2>
-<p>{$state.resultsReviewStatement}</p>
+  <h2>Review statement</h2>
+  <p>{$state.resultsReviewStatement}</p>
 
-<PolicyCheckResults />
+  <PolicyCheckResults />
 
-<table>
-  <tr>
-    <th>Remaining Policy Conflicts</th>
-    <th>Policy Conflict ID</th>
-    <th>Policy Conflict</th>
-    <th>Location Name</th>
-    <th>Commentary & Feedback</th>
-  </tr>
-  {#each $state.policyConflictLog as conflict, i}
-    {#if conflict.resolved != "Yes"}
-      <tr>
-        <th>{i + 1}</th>
-        <td>{policyConflictId($state, i)}</td>
-        <td>
-          {getFullPolicyConflict(conflict.conflict)}
-        </td>
-        <td>{conflict.locationName}</td>
-        <td>{conflict.notes}</td>
-      </tr>
-    {/if}
-  {/each}
-</table>
+  <table>
+    <tr>
+      <th>Remaining Policy Conflicts</th>
+      <th>Policy Conflict ID</th>
+      <th>Policy Conflict</th>
+      <th>Location Name</th>
+      <th>Commentary & Feedback</th>
+    </tr>
+    {#each $state.policyConflictLog as conflict, i}
+      {#if conflict.resolved != "Yes"}
+        <tr>
+          <th>{i + 1}</th>
+          <td>{policyConflictId($state, i)}</td>
+          <td>
+            {getFullPolicyConflict(conflict.conflict)}
+          </td>
+          <td>{conflict.locationName}</td>
+          <td>{conflict.notes}</td>
+        </tr>
+      {/if}
+    {/each}
+  </table>
 
-<SafetyCheckResults />
+  <SafetyCheckResults />
 
-<table>
-  <tr>
-    <th>Remaining Critical Issues</th>
-    <th>Critical ID</th>
-    <th>Critical Issue</th>
-    <th>Location Name</th>
-    <th>Commentary & Feedback</th>
-  </tr>
-  {#each $state.criticalIssues as critical, i}
-    {#if critical.resolved != "Yes"}
-      <tr>
-        <th>{i + 1}</th>
-        <td>{criticalIssueId($state, i)}</td>
-        <td>
-          {getFullCriticalIssue(critical.criticalIssue)}
-        </td>
-        <td>{critical.locationName}</td>
-        <td>{critical.notes}</td>
-      </tr>
-    {/if}
-  {/each}
-</table>
+  <table>
+    <tr>
+      <th>Remaining Critical Issues</th>
+      <th>Critical ID</th>
+      <th>Critical Issue</th>
+      <th>Location Name</th>
+      <th>Commentary & Feedback</th>
+    </tr>
+    {#each $state.criticalIssues as critical, i}
+      {#if critical.resolved != "Yes"}
+        <tr>
+          <th>{i + 1}</th>
+          <td>{criticalIssueId($state, i)}</td>
+          <td>
+            {getFullCriticalIssue(critical.criticalIssue)}
+          </td>
+          <td>{critical.locationName}</td>
+          <td>{critical.notes}</td>
+        </tr>
+      {/if}
+    {/each}
+  </table>
 
-<CheckDetails {results} />
+  <CheckDetails {results} />
+</div>

--- a/src/routes/route_check/results_export/ConvertToXlsx.svelte
+++ b/src/routes/route_check/results_export/ConvertToXlsx.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { state, currentFile } from "../data";
-  import { DefaultButton } from "govuk-svelte";
+  import { SecondaryButton } from "govuk-svelte";
   import { downloadExcelFile } from "./export";
   import { Loading } from "$lib";
 
@@ -17,7 +17,7 @@
   }
 </script>
 
-<DefaultButton on:click={download}>Convert to .xlsx</DefaultButton>
+<SecondaryButton on:click={download}>Export .xlsx</SecondaryButton>
 <p>
   <i>
     When you open the file, you need to force Excel to recalculate all formulas

--- a/src/routes/route_check/results_export/ConvertToXlsx.svelte
+++ b/src/routes/route_check/results_export/ConvertToXlsx.svelte
@@ -3,6 +3,7 @@
   import { SecondaryButton } from "govuk-svelte";
   import { downloadExcelFile } from "./export";
   import { Loading } from "$lib";
+  import downloadUrl from "$lib/assets/images/download.svg?url";
 
   let loading = "";
 
@@ -17,7 +18,10 @@
   }
 </script>
 
-<SecondaryButton on:click={download}>Export .xlsx</SecondaryButton>
+<SecondaryButton on:click={download}>
+  <img src={downloadUrl} alt="Export .xlsx" />
+  Export .xlsx
+</SecondaryButton>
 <p>
   <i>
     When you open the file, you need to force Excel to recalculate all formulas

--- a/src/routes/route_check/results_summary/+page.svelte
+++ b/src/routes/route_check/results_summary/+page.svelte
@@ -8,30 +8,32 @@
   let results = getResults($state);
 </script>
 
-<Overview {results} />
+<div class="govuk-width-container">
+  <Overview {results} />
 
-{#if $state.summary.checkType == "street"}
-  <LevelOfServiceTable
-    caption="Street Check Level of Service"
-    categories={results.levelOfService}
-    overall={results.overall}
-    overallLabel="Overall ATE Score"
-    barChart
-  />
-{:else if $state.summary.checkType == "path"}
-  <LevelOfServiceTable
-    caption="Path Check Level of Service"
-    categories={results.levelOfService}
-    overall={results.overall}
-    overallLabel="Overall ATE Score"
-    barChart
-  />
-{:else}
-  <h2>Select Street Check or Path Check for further results</h2>
-{/if}
+  {#if $state.summary.checkType == "street"}
+    <LevelOfServiceTable
+      caption="Street Check Level of Service"
+      categories={results.levelOfService}
+      overall={results.overall}
+      overallLabel="Overall ATE Score"
+      barChart
+    />
+  {:else if $state.summary.checkType == "path"}
+    <LevelOfServiceTable
+      caption="Path Check Level of Service"
+      categories={results.levelOfService}
+      overall={results.overall}
+      overallLabel="Overall ATE Score"
+      barChart
+    />
+  {:else}
+    <h2>Select Street Check or Path Check for further results</h2>
+  {/if}
 
-<TextArea
-  label="Review statement"
-  bind:value={$state.resultsReviewStatement}
-  hint="Use the space to provide overall feedback for the proposed scheme"
-/>
+  <TextArea
+    label="Review statement"
+    bind:value={$state.resultsReviewStatement}
+    hint="Use the space to provide overall feedback for the proposed scheme"
+  />
+</div>

--- a/src/routes/route_check/safety_check/Question.svelte
+++ b/src/routes/route_check/safety_check/Question.svelte
@@ -4,6 +4,7 @@
   import { state } from "../data";
   import { scoreToColor } from "$lib/colors";
   import { base } from "$app/paths";
+  import { defaultCriticalType } from "../lists";
 
   export let idx: number;
   export let label: string;
@@ -41,7 +42,13 @@
 
     {#if $state.safetyCheck.existingScores[idx - 1] == "C" || $state.safetyCheck.proposedScores[idx - 1] == "C"}
       <p>
-        <a href="{base}/route_check/problems_map">Log this critical issue</a>
+        <a
+          href="{base}/route_check/problems_map?kind=critical&code={defaultCriticalType(
+            idx,
+          )}"
+        >
+          Log this critical issue
+        </a>
       </p>
     {/if}
   </div>


### PR DESCRIPTION
Demo https://acteng.github.io/inspectorate_tools/log_pmp/route_check

From the UX study this morning, issues already reported in the feedback log, and other simple things I've spotted:

- When jumping to the PMP from the policy or safety check, prefill the critical/conflict type. When this is ambiguous (like from SA09 to logging critical 9A or 9B), always default to the "A" code.
- Move the "log this" link below the comments text box for policy check, to be consistent with safety check
- Let people export xlsx from the file management page too
- Rename those two buttons "Export .json" and "Export .xlsx" to be clear
- Have a green "Start" button on the file manager page after selecting an existing file
- Use the default govuk width-container left/right margins on all route check pages consistently, **except** for the PMP and JAT on the map portion, where horizontal space is at a premium
- Let the enter or escape key both work to save from the PMP or JAT form