### PR TITLE
Small layout fixes for JAT from feedback:

### DIFF
--- a/src/routes/route_check/jat_check/+page.svelte
+++ b/src/routes/route_check/jat_check/+page.svelte
@@ -9,6 +9,7 @@
   import { state } from "../data";
   import EditJunction from "./EditJunction.svelte";
   import { ClickableCard } from "$lib";
+  import { describeScore } from "./score";
 
   type Mode =
     | { kind: "list" }
@@ -62,7 +63,12 @@
       <ClickableCard
         name={junction.name || "Untitled junction"}
         on:click={() => (mode = { kind: "edit", idx, stage: "existing" })}
-      />
+      >
+        <div style="width: 100%; display: flex; justify-content: space-between">
+          <span>Existing: {describeScore(junction.existing)}</span>
+          <span>Proposed: {describeScore(junction.proposed)}</span>
+        </div>
+      </ClickableCard>
     {/each}
   </div>
 {:else if mode.kind == "edit"}
@@ -74,6 +80,20 @@
         Back to all junctions
       </SecondaryButton>
 
+      <WarningButton on:click={() => deleteJunction(getIdx(mode))}>
+        Delete junction
+      </WarningButton>
+    </ButtonGroup>
+
+    <TextInput label="Junction Name" bind:value={$state.jat[mode.idx].name} />
+  </div>
+
+  {#key mode.stage}
+    <EditJunction junctionIdx={mode.idx} stage={mode.stage}>
+      <p>
+        Currently editing {mode.stage} junction
+        <u>{$state.jat[mode.idx].name}</u>
+      </p>
       {#if mode.stage == "proposed"}
         <SecondaryButton
           on:click={() =>
@@ -89,16 +109,6 @@
           Edit Proposed
         </SecondaryButton>
       {/if}
-
-      <WarningButton on:click={() => deleteJunction(getIdx(mode))}>
-        Delete
-      </WarningButton>
-    </ButtonGroup>
-
-    <TextInput label="Junction Name" bind:value={$state.jat[mode.idx].name} />
-  </div>
-
-  {#key mode.stage}
-    <EditJunction junctionIdx={mode.idx} stage={mode.stage} />
+    </EditJunction>
   {/key}
 {/if}

--- a/src/routes/route_check/jat_check/score.ts
+++ b/src/routes/route_check/jat_check/score.ts
@@ -1,0 +1,21 @@
+import type { JunctionAssessment } from "../data";
+
+export function describeScore(ja: JunctionAssessment): string {
+  if (ja.movements.length == 0) {
+    return "No movements added";
+  }
+
+  let score = 0;
+  let totalPossible = 0;
+  for (let m of ja.movements) {
+    score += {
+      0: 0,
+      1: 1,
+      2: 2,
+      X: 0,
+    }[m.score];
+    totalPossible += 2;
+  }
+  let percent = (score / totalPossible) * 100;
+  return `${Math.round(percent)}%`;
+}


### PR DESCRIPTION
- show both scores near commentary box
- have save/delete buttons at both ends of the longer movement form
- when opening the movment form, ensure the position is at the top
- show total scores in the junction list
- move controls to make it more clear whether we're editing existing/proposed

Demo: https://acteng.github.io/inspectorate_tools/jat_layout/route_check/jat_check