### PR TITLE
Automatic backups of all user files

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build all branches
         run: |
           mkdir deployme
-          for branch in $(git branch -r | sed 's/origin\///' | grep -v nobuild_); do
+          for branch in $(git branch -r | sed 's/origin\///' | grep -v nobuild_ | grep -v 'HEAD -> origin/main'); do
             if [ "$branch" == "gh-pages" ]; then
               continue
             fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "exceljs": "^4.4.0",
         "govuk-frontend": "^5.4.1",
         "govuk-svelte": "github:acteng/govuk-svelte",
+        "jszip": "^3.10.1",
         "maplibre-gl": "^4.7.1",
         "scheme-sketcher-lib": "github:acteng/scheme-sketcher-lib",
         "svelte-chartjs": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "exceljs": "^4.4.0",
     "govuk-frontend": "^5.4.1",
     "govuk-svelte": "github:acteng/govuk-svelte",
+    "jszip": "^3.10.1",
     "maplibre-gl": "^4.7.1",
     "scheme-sketcher-lib": "github:acteng/scheme-sketcher-lib",
     "svelte-chartjs": "^3.1.5",

--- a/src/lib/files/FileManager.svelte
+++ b/src/lib/files/FileManager.svelte
@@ -148,6 +148,11 @@
 
       {#if fileList.length > 0}
         <h2>Manage existing files</h2>
+
+        <SecondaryButton on:click={() => files.exportAll()}>
+          Export all files for backup
+        </SecondaryButton>
+
         <table>
           <thead>
             <tr>

--- a/src/lib/files/index.ts
+++ b/src/lib/files/index.ts
@@ -124,7 +124,7 @@ export class LocalStorageFiles<StateType> {
 
   // Create and download a .zip with all JSON files
   async exportAll() {
-    let name = `route_check_backup_${getDateString()}`;
+    let name = `${this.prefix.slice(0, -1)}_backup_${getDateString()}`;
     let zip = new JSZip();
     let folder = zip.folder(name)!;
 

--- a/src/lib/files/index.ts
+++ b/src/lib/files/index.ts
@@ -1,3 +1,5 @@
+import { downloadBinaryFile } from "$lib";
+import JSZip from "jszip";
 import { get, type Writable } from "svelte/store";
 
 export { default as FileManager } from "./FileManager.svelte";
@@ -101,6 +103,24 @@ export class LocalStorageFiles<StateType> {
     } catch (_) {
       return "Error: invalid or broken file";
     }
+  }
+
+  // Create and download a .zip with all JSON files
+  async exportAll() {
+    let today = new Date();
+    let day = today.getDate().toString().padStart(2, "0");
+    let month = (today.getMonth() + 1).toString().padStart(2, "0");
+    let name = `route_check_backup_${day}_${month}_${today.getFullYear()}`;
+
+    let zip = new JSZip();
+    let folder = zip.folder(name)!;
+
+    for (let file of this.getFileList()) {
+      folder.file(`${file}.json`, window.localStorage.getItem(this.key(file))!);
+    }
+
+    let bytes = await zip.generateAsync({ type: "arraybuffer" });
+    downloadBinaryFile(bytes, `${name}.zip`);
   }
 
   // Initially set the currentFile and state store, based on the last opened file. If there is no last file, leaves both stores alone.


### PR DESCRIPTION
A user accidentally cleared their browser data, including local storage, and lost work. To mitigate this going forward,

1) The file manager splash screen now has a button to download a .zip with all JSON files. It's named something like `route_check_backup_27_01_2025.zip`
2) When the user first loads any page of any of the apps, if a backup hasn't been downloaded on today's date, then automatically download this .zip.