### PR TITLE
Let users make a copy of RC files

### DIFF
--- a/src/lib/files/FileManager.svelte
+++ b/src/lib/files/FileManager.svelte
@@ -45,6 +45,21 @@
     }
   }
 
+  function copyFile(filename: string) {
+    let newName = window.prompt(
+      `What do you want to call the new copy of ${filename}?`,
+      filename,
+    );
+    // TODO Handle overwriting
+    if (newName && newName != filename) {
+      let oldKey = files.key(filename);
+      let contents = window.localStorage.getItem(oldKey)!;
+      window.localStorage.setItem(files.key(newName), contents);
+      fileList = files.getFileList();
+      $currentFile = newName;
+    }
+  }
+
   function exportJSON(filename: string) {
     let key = files.key(filename);
     downloadGeneratedFile(
@@ -189,6 +204,9 @@
                     </SecondaryButton>
                     <SecondaryButton on:click={() => renameFile(filename)}>
                       Rename
+                    </SecondaryButton>
+                    <SecondaryButton on:click={() => copyFile(filename)}>
+                      Make a copy
                     </SecondaryButton>
                     <WarningButton on:click={() => deleteFile(filename)}>
                       Delete

--- a/src/routes/route_check/results_export/export.ts
+++ b/src/routes/route_check/results_export/export.ts
@@ -113,7 +113,8 @@ function summaryOfScheme(state: State, workbook: ExcelJS.Workbook) {
   sheet.getCell("C19").value = state.summary.totalRouteLengthKm;
   sheet.getCell("C20").value = state.summary.notes;
 
-  sheet.getCell("D22").value = state.summary.checkType == "path" ? "Path Check" : "Street Check";
+  sheet.getCell("D22").value =
+    state.summary.checkType == "path" ? "Path Check" : "Street Check";
 
   // The route could be split into many pieces. Arbitrarily use coordinates from the first LineString.
   for (let f of state.summary.networkMap.features) {


### PR DESCRIPTION
A user requested this feature, to assess two similar schemes and avoid manually copying everything over.

I think the page becomes a bit cramped with this button placement:
![image](https://github.com/user-attachments/assets/bcb21fd2-6f27-4a7b-a942-9d76bf95a870)
But this is how [govuk-width-container](https://design-system.service.gov.uk/styles/layout/) is intended to work