### PR TITLE
Various fixes - resolves  #112

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3787,7 +3787,7 @@
     },
     "node_modules/govuk-svelte": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/acteng/govuk-svelte.git#2a9ab3754ed5af6958e999268e2fd1785852fe5a",
+      "resolved": "git+ssh://git@github.com/acteng/govuk-svelte.git#abdd5ec4c6b910356a11b999c1ffdc78043dbe2f",
       "dependencies": {
         "govuk-frontend": "^5.4.1",
         "sass": "^1.77.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3787,7 +3787,7 @@
     },
     "node_modules/govuk-svelte": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/acteng/govuk-svelte.git#abdd5ec4c6b910356a11b999c1ffdc78043dbe2f",
+      "resolved": "git+ssh://git@github.com/acteng/govuk-svelte.git#29db9884aa648300eef5659c3eb1cc21d5b1f48b",
       "dependencies": {
         "govuk-frontend": "^5.4.1",
         "sass": "^1.77.8",

--- a/src/routes/route_check/results_export/ConvertToXlsx.svelte
+++ b/src/routes/route_check/results_export/ConvertToXlsx.svelte
@@ -39,6 +39,19 @@
         everything mapped when the route is split into multiple pieces.
       </li>
       <li>The map weblink only shows the route start point.</li>
+      <li>
+        Graphs will not be exported. To share a summary of results, export
+        relevant results pages as .pdf files from your we browser.
+      </li>
+      <li>
+        Formatting changes may occur, including spreadsheet tab colours and
+        other minor inconsistencies.
+      </li>
+      <li>
+        In the JAT tab, only the scores will be exported - movement diagrams
+        will be lost.
+      </li>
+      <li>The spreadsheet will be completely unprotected.</li>
     </ul>
   </WarningText>
   <SecondaryButton on:click={() => (open = false)}>OK</SecondaryButton>

--- a/src/routes/route_check/route_map/+page.svelte
+++ b/src/routes/route_check/route_map/+page.svelte
@@ -186,12 +186,14 @@
           bind:value={$state.summary.assessedRouteLengthKm}
           width={6}
           min={0}
+          hint={"Please provide 2 decimal places"}
         />
         <DecimalInput
           label="Total route length (km)"
           bind:value={$state.summary.totalRouteLengthKm}
           width={6}
           min={0}
+          hint={"Please provide 2 decimal places"}
         />
 
         <Basemap />


### PR DESCRIPTION
resolves -
Authority list not in alphabetical order
Other -> Other, please specify
Indicate to user that route length should be to 2 decimal places
remove one set of save/deletebuttons from JAT movementform
add to excel export caveats